### PR TITLE
Support Lowest Possible MacOS Version: 10.14

### DIFF
--- a/OpinionatedTimer.xcodeproj/project.pbxproj
+++ b/OpinionatedTimer.xcodeproj/project.pbxproj
@@ -285,6 +285,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				PRODUCT_BUNDLE_IDENTIFIER = zzada.OpinionatedTimer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -303,6 +304,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				PRODUCT_BUNDLE_IDENTIFIER = zzada.OpinionatedTimer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
I had to downgrade the target version to MacOS 10.14 to run on my machine. This is the lowest possible version as `UNUserNotificationCenter` is only available in macOS 10.14 or newer.